### PR TITLE
Preserve active layer & set better default values

### DIFF
--- a/polygonizer_dockwidget.py
+++ b/polygonizer_dockwidget.py
@@ -95,6 +95,9 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
     def eventPushButtonRunPolygonizerOnClick(self):
         project = QgsProject.instance()
 
+        # Capture the currently selected layer, so we can set it active again when we're done
+        current_layer = iface.activeLayer()
+
         # clean up previous executions workspace layers
         layers = project.mapLayers()
         for layer_key in layers:
@@ -467,6 +470,9 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         self.add_layer_to_output_group(
             interconnect_added_layer, output_group_name, layer_root
         )
+
+        # set the "active layer" back to what it was when we started
+        iface.setActiveLayer(current_layer)
 
     def closeEvent(self, event):
         self.closingPlugin.emit()

--- a/polygonizer_dockwidget_base.ui
+++ b/polygonizer_dockwidget_base.ui
@@ -56,7 +56,7 @@
            <number>25</number>
           </property>
           <property name="maximum">
-           <number>300</number>
+           <number>500</number>
           </property>
           <property name="value">
            <number>100</number>
@@ -69,7 +69,7 @@
            <number>25</number>
           </property>
           <property name="maximum">
-           <number>300</number>
+           <number>500</number>
           </property>
           <property name="value">
            <number>100</number>
@@ -86,26 +86,26 @@
         <item>
          <widget class="QSpinBox" name="idealSegmentLengthSpinbox">
           <property name="minimum">
-           <number>50</number>
+           <number>25</number>
           </property>
           <property name="maximum">
-           <number>250</number>
+           <number>1000</number>
           </property>
           <property name="value">
-           <number>150</number>
+           <number>200</number>
           </property>
          </widget>
         </item>
         <item>
          <widget class="QSlider" name="idealSegmentLengthSlider">
           <property name="minimum">
-           <number>50</number>
+           <number>25</number>
           </property>
           <property name="maximum">
-           <number>250</number>
+           <number>1000</number>
           </property>
           <property name="value">
-           <number>150</number>
+           <number>200</number>
           </property>
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -125,7 +125,7 @@
            <number>100</number>
           </property>
           <property name="value">
-           <number>40</number>
+           <number>30</number>
           </property>
          </widget>
         </item>
@@ -138,7 +138,7 @@
            <number>100</number>
           </property>
           <property name="value">
-           <number>40</number>
+           <number>30</number>
           </property>
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -159,20 +159,20 @@
         <item>
          <widget class="QSpinBox" name="maxSnapLengthSpinbox">
           <property name="maximum">
-           <number>150</number>
+           <number>500</number>
           </property>
           <property name="value">
-           <number>30</number>
+           <number>150</number>
           </property>
          </widget>
         </item>
         <item>
          <widget class="QSlider" name="maxSnapLengthSlider">
           <property name="maximum">
-           <number>150</number>
+           <number>500</number>
           </property>
           <property name="value">
-           <number>30</number>
+           <number>150</number>
           </property>
           <property name="orientation">
            <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
# Context
These are a couple of small things that came to mind while I was working on the parent branch, but I didn't want to clutter it was with them. There isn't an issue associated with them, and they are more polish than features.

# Contents
* Preserve the selected layer after polygons are created. 
  * This makes it much easier to play with the sliders and find what you want.
* Set more generous default ranges for input parameters
* Set defaults closer inline with existing polygons