### PR TITLE
Iteratively clip polygons until none overlap

### DIFF
--- a/polygonizer_dockwidget.py
+++ b/polygonizer_dockwidget.py
@@ -487,7 +487,6 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         pass_count = 0
         while has_overlaps: # just enough
             pass_count += 1
-            # QgsMessageLog.logMessage(f"Pass #{pass_count}", "Polygonizer")
             found_overlapping_feature_count = 0
             has_overlaps = False  # Reset flag for each iteration
 
@@ -510,8 +509,6 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                     if geometry1.intersection(geometry2) and overlap_area > 0.01:
                         found_overlapping_feature_count += 1
                         has_overlaps = True  # Set flag to True since we found an overlap
-                        # QgsMessageLog.logMessage(f"{found_overlaps}: Feature {feature1.id()} overlaps with feature {feature2.id()}", "Polygonizer")
-                        # QgsMessageLog.logMessage(f"Overlap area: {overlap_area}", "Polygonizer")
 
                         # Your code to handle the overlapping features
                         if geometry1.area() < geometry2.area():
@@ -525,8 +522,6 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                             # Update geometry immediately in the data provider
                             provider.changeGeometryValues({feature1.id(): new_geom})
  
-            # QgsMessageLog.logMessage(f"Previous Found Count: {found_overlaps}", "Polygonizer")
-
         # add our new layer with our intersectional polygons to the output group
         interconnect_added_layer = project.addMapLayer(interconnect_polygons_layer)
         self.add_layer_to_output_group(

--- a/polygonizer_dockwidget.py
+++ b/polygonizer_dockwidget.py
@@ -483,17 +483,13 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
         # Flag to track if any overlapping pairs are found
         has_overlaps = True
+        # keep track of how many iterations for debugging
         pass_count = 0
-        #for _ in iter([True]): # just once
-        #while pass_count < 5: # five times always
         while has_overlaps: # just enough
             pass_count += 1
             # QgsMessageLog.logMessage(f"Pass #{pass_count}", "Polygonizer")
-            found_overlaps = 0
+            found_overlapping_feature_count = 0
             has_overlaps = False  # Reset flag for each iteration
-
-            # Initialize a list to hold the modified features
-            modified_features = []
 
             # Iterate over each feature in the merged_layer
             for feature1 in merged_layer.getFeatures():
@@ -512,7 +508,7 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
                     # Check for intersection
                     if geometry1.intersection(geometry2) and overlap_area > 0.01:
-                        found_overlaps += 1
+                        found_overlapping_feature_count += 1
                         has_overlaps = True  # Set flag to True since we found an overlap
                         # QgsMessageLog.logMessage(f"{found_overlaps}: Feature {feature1.id()} overlaps with feature {feature2.id()}", "Polygonizer")
                         # QgsMessageLog.logMessage(f"Overlap area: {overlap_area}", "Polygonizer")
@@ -529,15 +525,7 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                             # Update geometry immediately in the data provider
                             provider.changeGeometryValues({feature1.id(): new_geom})
  
-                            # Add it to the list of modified features
-                            # modified_features.append(feature1)
-
-            # Update the layer with modified features
-            #if modified_features:
-                #provider = merged_layer.dataProvider()
-                #provider.changeGeometryValues({f.id(): f.geometry() for f in modified_features})
-
-            QgsMessageLog.logMessage(f"Previous Found Count: {found_overlaps}", "Polygonizer")
+            # QgsMessageLog.logMessage(f"Previous Found Count: {found_overlaps}", "Polygonizer")
 
         # add our new layer with our intersectional polygons to the output group
         interconnect_added_layer = project.addMapLayer(interconnect_polygons_layer)

--- a/polygonizer_dockwidget.py
+++ b/polygonizer_dockwidget.py
@@ -461,7 +461,12 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         segmented_roads_layer.updateExtents()
         interconnect_polygons_layer.updateExtents()
 
-        merged_layer = QgsVectorLayer("Polygon?crs=epsg:2277", "Workspace: Pre-clip Polygons", "memory")
+        # add our new layer with our intersectional polygons to the output group
+        interconnect_added_layer = project.addMapLayer(interconnect_polygons_layer)
+        self.add_layer_to_output_group(
+            interconnect_added_layer, output_group_name, layer_root
+        )
+        merged_layer = QgsVectorLayer("Polygon?crs=epsg:2277", "Workspace: Clipped Output", "memory")
 
         # Get the data provider to edit the layer
         provider = merged_layer.dataProvider()
@@ -522,11 +527,7 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                             # Update geometry immediately in the data provider
                             provider.changeGeometryValues({feature1.id(): new_geom})
  
-        # add our new layer with our intersectional polygons to the output group
-        interconnect_added_layer = project.addMapLayer(interconnect_polygons_layer)
-        self.add_layer_to_output_group(
-            interconnect_added_layer, output_group_name, layer_root
-        )
+
 
     def closeEvent(self, event):
         self.closingPlugin.emit()

--- a/polygonizer_dockwidget.py
+++ b/polygonizer_dockwidget.py
@@ -461,6 +461,31 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         segmented_roads_layer.updateExtents()
         interconnect_polygons_layer.updateExtents()
 
+        merged_layer = QgsVectorLayer("Polygon?crs=epsg:2277", "Workspace: Pre-clip Polygons", "memory")
+
+        # Get the data provider to edit the layer
+        provider = merged_layer.dataProvider()
+
+        # Initialize a list to hold new features
+        new_features = []
+
+        for feature in intersection_polygons_layer.getFeatures():
+            new_features.append(feature)
+
+        for feature in interconnect_polygons_layer.getFeatures():
+            new_features.append(feature)
+
+        # Add new features to the merged layer
+        provider.addFeatures(new_features)
+
+        # Add the merged layer to the map
+        QgsProject.instance().addMapLayer(merged_layer)
+
+        
+        
+
+
+
         # add our new layer with our intersectional polygons to the output group
         interconnect_added_layer = project.addMapLayer(interconnect_polygons_layer)
         self.add_layer_to_output_group(

--- a/polygonizer_dockwidget.py
+++ b/polygonizer_dockwidget.py
@@ -515,7 +515,6 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                         found_overlapping_feature_count += 1
                         has_overlaps = True  # Set flag to True since we found an overlap
 
-                        # Your code to handle the overlapping features
                         if geometry1.area() < geometry2.area():
 
                             # Clip the smaller geometry out of the larger one

--- a/polygonizer_dockwidget.py
+++ b/polygonizer_dockwidget.py
@@ -103,6 +103,7 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                 project.removeMapLayer(layer.id())
 
         # create a group and move it to the top of the layer list for output
+        # FIXME this would be a great parameter
         output_group_name = "Polygonizer Output"
         layer_root = project.layerTreeRoot()
         group = layer_root.findGroup(output_group_name)

--- a/polygonizer_dockwidget.py
+++ b/polygonizer_dockwidget.py
@@ -481,9 +481,39 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         # Add the merged layer to the map
         QgsProject.instance().addMapLayer(merged_layer)
 
-        
-        
+        # Initialize a list to hold the modified features
+        modified_features = []
 
+        # Iterate over each feature in the merged_layer
+        for feature1 in merged_layer.getFeatures():
+            geometry1 = feature1.geometry()
+            
+            # Nested iteration to compare with every other feature
+            for feature2 in merged_layer.getFeatures():
+                # Skip self-comparison
+                if feature1.id() == feature2.id():
+                    continue
+                
+                geometry2 = feature2.geometry()
+                
+                # Check for intersection
+                if geometry1.intersects(geometry2):
+                    # QgsMessageLog.logMessage(f"Feature {feature1.id()} intersects with feature {feature2.id()}", "Polygonizer")
+
+                    # Your code to handle the overlapping features
+                    if geometry1.area() < geometry2.area():
+                        # Clip the smaller geometry out of the larger one
+                        new_geom = geometry1.difference(geometry2)
+                        
+                        # Update the feature's geometry
+                        feature1.setGeometry(new_geom)
+                        
+                        # Add it to the list of modified features
+                        modified_features.append(feature1)
+
+        # Update the layer with the modified features
+        provider = merged_layer.dataProvider()
+        provider.changeGeometryValues({f.id(): f.geometry() for f in modified_features})
 
 
         # add our new layer with our intersectional polygons to the output group

--- a/polygonizer_dockwidget.py
+++ b/polygonizer_dockwidget.py
@@ -526,7 +526,6 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                             
                             # Update geometry immediately in the data provider
                             provider.changeGeometryValues({feature1.id(): new_geom})
- 
 
 
     def closeEvent(self, event):

--- a/polygonizer_dockwidget.py
+++ b/polygonizer_dockwidget.py
@@ -483,12 +483,12 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
 
         # Flag to track if any overlapping pairs are found
         has_overlaps = True
-        # while has_overlaps:
         pass_count = 0
-        #for _ in iter([True]):
-        while pass_count < 5:
+        #for _ in iter([True]): # just once
+        #while pass_count < 5: # five times always
+        while has_overlaps: # just enough
             pass_count += 1
-            QgsMessageLog.logMessage(f"Pass #{pass_count}", "Polygonizer")
+            # QgsMessageLog.logMessage(f"Pass #{pass_count}", "Polygonizer")
             found_overlaps = 0
             has_overlaps = False  # Reset flag for each iteration
 
@@ -510,14 +510,12 @@ class PolygonizerDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
                     intersection_geom = geometry1.intersection(geometry2)
                     overlap_area = intersection_geom.area()
 
-                    QgsMessageLog.logMessage(f"Overlap area: {overlap_area}", "Polygonizer")
-
-                    
                     # Check for intersection
                     if geometry1.intersection(geometry2) and overlap_area > 0.01:
                         found_overlaps += 1
                         has_overlaps = True  # Set flag to True since we found an overlap
-                        QgsMessageLog.logMessage(f"{found_overlaps}: Feature {feature1.id()} overlaps with feature {feature2.id()}", "Polygonizer")
+                        # QgsMessageLog.logMessage(f"{found_overlaps}: Feature {feature1.id()} overlaps with feature {feature2.id()}", "Polygonizer")
+                        # QgsMessageLog.logMessage(f"Overlap area: {overlap_area}", "Polygonizer")
 
                         # Your code to handle the overlapping features
                         if geometry1.area() < geometry2.area():


### PR DESCRIPTION
# Associated Issues

https://github.com/cityofaustin/atd-data-tech/issues/13468

# PR Contents

This PR contains the following additions to the polygonizer routine:

* Combine the two layers (intersection-polygons and interconnecting-road-polygons into one layer of all polygons
* Iterative over the set, comparing one to another, and clipping the small one by the large one when they overlap. 
  * When this loop finds no more overlapping shapes, they all are clipped from one another and no longer overlap.

# Testing

Like the other PR, https://github.com/cityofaustin/dts-qgis-polygon-plugin/pull/1, I think this is best tested by demo & code review. I'm open to anything, of course! Thanks!